### PR TITLE
🔒️ Use timing-safe comparison for admin secret key

### DIFF
--- a/app/controllers/admin/emails_controller.rb
+++ b/app/controllers/admin/emails_controller.rb
@@ -25,7 +25,7 @@ class Admin::EmailsController < ApplicationController
   private
 
   def authenticate_relying_party
-    unless params[:secret_key] == relying_party.secret_key_base64
+    unless ActiveSupport::SecurityUtils.secure_compare(params[:secret_key].to_s, relying_party.secret_key_base64)
       head :forbidden
     end
   end


### PR DESCRIPTION
## Summary
- Replaces `==` with `ActiveSupport::SecurityUtils.secure_compare` for admin API secret key validation
- String `==` is vulnerable to timing attacks — attackers can extract the secret key byte-by-byte by measuring response times

## Test plan
- [ ] Test admin email API endpoints (`POST /admin/relying_parties/:id/emails`, `DELETE /admin/relying_parties/:id/emails`) with correct and incorrect secret keys
- [ ] Verify correct key still grants access, wrong key still returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)