### PR TITLE
🔒️ Add rate limiting with rack-attack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem 'color-generator'
 
 gem 'airbrake'
 
+# Rate limiting
+gem 'rack-attack'
+
 # For background processing powered by RabbitMQ
 gem 'sneakers', '2.12.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.13)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -456,6 +458,7 @@ DEPENDENCIES
   local_time
   pg
   puma
+  rack-attack
   rails (~> 8)
   rails_event_store (= 1.3.0)
   rbnacl (= 7.1.1)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,27 @@
+Rack::Attack.throttle("authentication/ip", limit: 20, period: 1.minute) do |req|
+  req.ip if req.path == "/authenticate" && req.post?
+end
+
+Rack::Attack.throttle("authentication/email", limit: 10, period: 1.minute) do |req|
+  req.params["email"].to_s.downcase.strip if req.path == "/authenticate" && req.post?
+end
+
+Rack::Attack.throttle("password_recovery/ip", limit: 5, period: 1.minute) do |req|
+  req.ip if req.path == "/password/recover" && req.post?
+end
+
+Rack::Attack.throttle("password_recovery/email", limit: 3, period: 10.minutes) do |req|
+  req.params["email"].to_s.downcase.strip if req.path == "/password/recover" && req.post?
+end
+
+Rack::Attack.throttle("email_verification/ip", limit: 10, period: 1.minute) do |req|
+  req.ip if req.path == "/registrations/verify_email" && req.post?
+end
+
+Rack::Attack.throttle("registrations/ip", limit: 10, period: 1.minute) do |req|
+  req.ip if req.path == "/registrations" && req.post?
+end
+
+Rack::Attack.throttled_responder = lambda do |_env|
+  [429, { "Content-Type" => "text/plain" }, ["Too many requests. Please try again later.\n"]]
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -23,5 +23,6 @@ Rack::Attack.throttle("registrations/ip", limit: 10, period: 1.minute) do |req|
 end
 
 Rack::Attack.throttled_responder = lambda do |_env|
-  [429, { "Content-Type" => "text/plain" }, ["Too many requests. Please try again later.\n"]]
+  html = Rails.public_path.join("429.html").read
+  [429, { "Content-Type" => "text/html" }, [html]]
 end

--- a/public/429.html
+++ b/public/429.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Too many requests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background-color: #f9fafb;
+      color: #1f2937;
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .card {
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.75rem;
+      box-shadow: 0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1);
+      max-width: 28rem;
+      width: 90%;
+      padding: 2.5rem;
+      text-align: center;
+    }
+    h1 {
+      font-size: 1.25rem;
+      font-weight: 600;
+      margin: 0 0 0.75rem;
+    }
+    p {
+      color: #6b7280;
+      margin: 0 0 1.5rem;
+      line-height: 1.5;
+    }
+    a {
+      display: inline-block;
+      padding: 0.5rem 1.5rem;
+      background-color: #1f2937;
+      color: white;
+      text-decoration: none;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+    }
+    a:hover { background-color: #374151; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Slow down a little</h1>
+    <p>You've made too many requests. Please wait a moment and try again.</p>
+    <a href="javascript:history.back()">Go back</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `rack-attack` gem for request throttling
- Throttles authentication (20/min per IP, 10/min per email), password recovery (5/min per IP, 3/10min per email), email verification (10/min per IP), and registration (10/min per IP)
- Returns 429 with plain text message when throttled
- Prevents credential stuffing, brute force attacks, and email bombing

## Test plan
- [ ] Run `bundle install` to install `rack-attack`
- [ ] Run `bin/rails test`
- [ ] Test rapid login attempts — verify 429 response after threshold
- [ ] Test normal login flow still works within limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)