### PR TITLE
🔒️ Fix XSS vulnerabilities in admin view and relying party name

### DIFF
--- a/app/models/authentication/relying_party.rb
+++ b/app/models/authentication/relying_party.rb
@@ -49,7 +49,7 @@ class Authentication::RelyingParty
 
   def self.http_client
     Faraday.new do |builder|
-      builder.use :http_cache, store: Rails.cache, logger: Rails.logger, serializer: Marshal
+      builder.use :http_cache, store: Rails.cache, logger: Rails.logger, serializer: JSON
       builder.use FaradayMiddleware::FollowRedirects
       builder.adapter Faraday.default_adapter
     end
@@ -150,7 +150,7 @@ class Authentication::RelyingParty
   end
 
   def name_html
-    name.gsub(' ', '&nbsp').html_safe
+    ERB::Util.html_escape(name).gsub(' ', '&nbsp;').html_safe
   end
 
   def default_redirect_uri

--- a/app/views/admin/relying_parties/show.html.erb
+++ b/app/views/admin/relying_parties/show.html.erb
@@ -186,7 +186,7 @@
 <p>
   we get
 </p>
-<pre><code><%= raw JSON.pretty_generate(admin_relying_party.well_knowns) %></code></pre>
+<pre><code><%= JSON.pretty_generate(admin_relying_party.well_knowns) %></code></pre>
 
 <% if admin_relying_party.logo_data.present? %>
   <p>
@@ -199,7 +199,7 @@
   <%= name %> caches the JSON based on the HTTP headers:
 </p>
 
-<pre><code><%= raw JSON.pretty_generate(admin_relying_party.http_headers || {}) %></code></pre>
+<pre><code><%= JSON.pretty_generate(admin_relying_party.http_headers || {}) %></code></pre>
 
 <p>
   The configuration is needed everytime we show a sign in screen for <%= admin_relying_party.name %> to a user, so allowing <%= name %> to cache it seems sensible.


### PR DESCRIPTION
## Summary
- **Admin view**: Remove `raw()` from JSON output — `well_knowns` and `http_headers` are fetched from external URLs, so a malicious relying party could inject scripts
- **Relying party name**: Escape with `ERB::Util.html_escape` before calling `html_safe`, since `name` comes from external `.well-known/promise.json`
- Fix `&nbsp` → `&nbsp;` (missing semicolon)

## Test plan
- [ ] Visit admin relying party page — verify JSON still renders correctly (now HTML-escaped, but inside `<pre><code>` it should look the same)
- [ ] Verify relying party names with special characters render safely
- [ ] Run `bin/rails test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)