### PR TITLE
🔒️ Replace Marshal with JSON serializer in Faraday HTTP cache

### DIFF
--- a/app/models/authentication/relying_party.rb
+++ b/app/models/authentication/relying_party.rb
@@ -49,7 +49,7 @@ class Authentication::RelyingParty
 
   def self.http_client
     Faraday.new do |builder|
-      builder.use :http_cache, store: Rails.cache, logger: Rails.logger, serializer: Marshal
+      builder.use :http_cache, store: Rails.cache, logger: Rails.logger, serializer: JSON
       builder.use FaradayMiddleware::FollowRedirects
       builder.adapter Faraday.default_adapter
     end

--- a/test/models/authentication/relying_party_test.rb
+++ b/test/models/authentication/relying_party_test.rb
@@ -92,6 +92,31 @@ class Authentication::RelyingPartyTest < ActiveSupport::TestCase
     assert @relying_party.valid?
   end
 
+  test 'http_client uses JSON serializer for cache' do
+    client = @described_class.http_client
+    cache_middleware = client.builder.handlers.find { |h| h.name.include?('HttpCache') }
+    assert cache_middleware, 'Expected http_cache middleware to be present'
+
+    # Verify JSON serializer by doing a real cached round-trip
+    url = 'https://cache-test.example.com/.well-known/promise.json'
+    body = { name: 'Test App' }.to_json
+
+    stub_request(:get, url)
+      .to_return(
+        status: 200,
+        body: body,
+        headers: { 'Cache-Control' => 'max-age=300', 'Content-Type' => 'application/json' }
+      )
+
+    # First request hits the stub
+    response1 = @described_class.fetch(url)
+    assert_equal body, response1.body
+
+    # Second request should be served from cache (no second stub hit)
+    response2 = @described_class.fetch(url)
+    assert_equal body, response2.body
+  end
+
   test 'authenticating legacy account' do
     @relying_party.legacy_account_authentication_url = 'https://hello.world'
     @relying_party.legacy_account_forgot_password_url = 'http://hello.world'


### PR DESCRIPTION
## Summary
- Replaces `Marshal` with `JSON` as the serializer for Faraday HTTP cache
- `Marshal` deserialization can execute arbitrary code — if cache is ever poisoned, this becomes RCE

## Test plan
- [ ] Run `bin/rails test`
- [ ] Test login flow with a relying party — verify `.well-known/promise.json` fetching and caching still works
- [ ] Clear cache and verify relying party config is re-fetched correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)