### PR TITLE
🔒️ Change production log level from debug to info

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
## Summary
- Changes production log level from `:debug` to `:info`
- Debug logging can leak sensitive information even with parameter filtering (SQL queries, cache contents, full request details)

## Test plan
- [ ] Deploy and verify logs still contain useful info-level messages
- [ ] Verify no sensitive data visible in production logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)