### PR TITLE
✨ Add /oauth2/token with RFC 8693 + RFC 9449 DPoP

### DIFF
--- a/app/controllers/oauth2/token_controller.rb
+++ b/app/controllers/oauth2/token_controller.rb
@@ -1,0 +1,61 @@
+class Oauth2::TokenController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:exchange]
+
+  GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token-exchange'.freeze
+  ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token'.freeze
+  ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token'.freeze
+  ISSUER = 'https://promiseauthentication.org'.freeze
+  ACCESS_TOKEN_TTL = 120
+
+  def exchange
+    return render_error('invalid_request', 'unsupported grant_type', status: :bad_request) unless params[:grant_type] == GRANT_TYPE
+    return render_error('invalid_request', 'unsupported subject_token_type', status: :bad_request) unless params[:subject_token_type] == ID_TOKEN_TYPE
+    return render_error('invalid_request', 'subject_token is required', status: :bad_request) if params[:subject_token].blank?
+    return render_error('invalid_request', 'audience is required', status: :bad_request) if params[:audience].blank?
+
+    proof = Dpop::Proof.verify!(
+      request.headers['DPoP'],
+      http_method: request.method,
+      http_url: request.url
+    )
+
+    subject = Authentication::IdToken.parse(params[:subject_token])
+
+    access_token = mint_access_token(sub: subject.sub, audience: params[:audience], jkt: proof.jkt)
+
+    render json: {
+      access_token: access_token,
+      issued_token_type: ACCESS_TOKEN_TYPE,
+      token_type: 'Bearer',
+      expires_in: ACCESS_TOKEN_TTL
+    }
+  rescue Dpop::Proof::InvalidProof => e
+    render_error('invalid_dpop_proof', e.message, status: :bad_request)
+  rescue JWT::DecodeError, JWT::VerificationError, JWT::ExpiredSignature
+    render_error('invalid_grant', 'subject_token is not valid', status: :bad_request)
+  end
+
+  private
+
+  def mint_access_token(sub:, audience:, jkt:)
+    cert = Trust::Certificate.current
+    kid = cert.public_key.to_jwk['kid']
+    now = Time.now.to_i
+
+    payload = {
+      iss: ISSUER,
+      sub: sub,
+      aud: audience,
+      iat: now,
+      exp: now + ACCESS_TOKEN_TTL,
+      jti: SecureRandom.uuid,
+      cnf: { jkt: jkt }
+    }
+
+    JWT.encode(payload, cert.private_key, 'ES512', kid: kid)
+  end
+
+  def render_error(code, description, status:)
+    render json: { error: code, error_description: description }, status: status
+  end
+end

--- a/app/controllers/oauth2/token_controller.rb
+++ b/app/controllers/oauth2/token_controller.rb
@@ -1,11 +1,16 @@
 class Oauth2::TokenController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: [:exchange]
+  skip_before_action :verify_authenticity_token, only: [:exchange, :preflight]
+  before_action :set_cors_headers, only: [:exchange, :preflight]
 
   GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token-exchange'.freeze
   ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token'.freeze
   ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token'.freeze
   ISSUER = ENV.fetch('PROMISE_ISSUER', 'https://promiseauthentication.org').freeze
   ACCESS_TOKEN_TTL = 120
+
+  def preflight
+    head :no_content
+  end
 
   def exchange
     return render_error('invalid_request', 'unsupported grant_type', status: :bad_request) unless params[:grant_type] == GRANT_TYPE
@@ -57,5 +62,15 @@ class Oauth2::TokenController < ApplicationController
 
   def render_error(code, description, status:)
     render json: { error: code, error_description: description }, status: status
+  end
+
+  def set_cors_headers
+    origin = request.headers['Origin']
+    return if origin.blank?
+    response.set_header('Access-Control-Allow-Origin', origin)
+    response.set_header('Access-Control-Allow-Methods', 'POST, OPTIONS')
+    response.set_header('Access-Control-Allow-Headers', 'Content-Type, DPoP, Authorization')
+    response.set_header('Access-Control-Max-Age', '3600')
+    response.set_header('Vary', 'Origin')
   end
 end

--- a/app/controllers/oauth2/token_controller.rb
+++ b/app/controllers/oauth2/token_controller.rb
@@ -4,7 +4,7 @@ class Oauth2::TokenController < ApplicationController
   GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token-exchange'.freeze
   ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token'.freeze
   ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token'.freeze
-  ISSUER = 'https://promiseauthentication.org'.freeze
+  ISSUER = ENV.fetch('PROMISE_ISSUER', 'https://promiseauthentication.org').freeze
   ACCESS_TOKEN_TTL = 120
 
   def exchange

--- a/app/domain/authentication/id_token.rb
+++ b/app/domain/authentication/id_token.rb
@@ -24,7 +24,7 @@ class Authentication::IdToken
       jti: jti,
       sub: sub,
       aud: aud,
-      iss: 'https://promiseauthentication.org',
+      iss: ENV.fetch('PROMISE_ISSUER', 'https://promiseauthentication.org'),
       iat: (iat || Time.now).to_i,
       nonce: nonce
     }.compact

--- a/app/domain/dpop/proof.rb
+++ b/app/domain/dpop/proof.rb
@@ -1,0 +1,92 @@
+require 'json/jwt'
+
+module Dpop
+  class Proof
+    class InvalidProof < StandardError; end
+
+    TYP = 'dpop+jwt'.freeze
+    SUPPORTED_ALGS = %w[ES256 ES384 ES512 RS256 PS256].freeze
+    DEFAULT_SKEW = 60
+    JTI_TTL = 120
+
+    attr_reader :jkt, :jti
+
+    def self.verify!(header_value, http_method:, http_url:, clock_skew: DEFAULT_SKEW, now: Time.now)
+      raise InvalidProof, 'missing DPoP header' if header_value.blank?
+
+      new(header_value, http_method: http_method, http_url: http_url, clock_skew: clock_skew, now: now).tap(&:verify!)
+    end
+
+    def initialize(token, http_method:, http_url:, clock_skew:, now:)
+      @token = token
+      @http_method = http_method.to_s.upcase
+      @http_url = canonical_url(http_url)
+      @clock_skew = clock_skew
+      @now = now
+    end
+
+    def verify!
+      header, payload = decode_and_verify_signature!
+      verify_header!(header)
+      verify_payload!(payload)
+      @jti = payload['jti']
+      @jkt = JSON::JWK.new(header['jwk']).thumbprint
+      claim_jti!
+      self
+    end
+
+    private
+
+    def decode_and_verify_signature!
+      header = unverified_header
+      raise InvalidProof, 'unsupported alg' unless SUPPORTED_ALGS.include?(header['alg'])
+      raise InvalidProof, 'missing jwk in header' unless header['jwk'].is_a?(Hash)
+
+      key = JSON::JWK.new(header['jwk']).to_key
+      payload, verified_header = JWT.decode(@token, key, true, algorithm: header['alg'])
+      [verified_header, payload]
+    rescue JWT::DecodeError, JWT::VerificationError, OpenSSL::PKey::PKeyError => e
+      raise InvalidProof, "signature invalid: #{e.class}"
+    end
+
+    def unverified_header
+      _payload, header = JWT.decode(@token, nil, false)
+      header
+    rescue JWT::DecodeError => e
+      raise InvalidProof, "malformed proof: #{e.class}"
+    end
+
+    def verify_header!(header)
+      raise InvalidProof, 'wrong typ' unless header['typ'] == TYP
+    end
+
+    def verify_payload!(payload)
+      raise InvalidProof, 'wrong htm' unless payload['htm'].to_s.upcase == @http_method
+      raise InvalidProof, 'wrong htu' unless canonical_url(payload['htu']) == @http_url
+      raise InvalidProof, 'missing jti' if payload['jti'].blank?
+
+      iat = payload['iat']
+      raise InvalidProof, 'missing iat' unless iat.is_a?(Integer)
+
+      now_i = @now.to_i
+      raise InvalidProof, 'iat too far in past' if iat < now_i - @clock_skew
+      raise InvalidProof, 'iat too far in future' if iat > now_i + @clock_skew
+    end
+
+    def claim_jti!
+      key = "dpop:jti:#{@jti}"
+      if Rails.cache.exist?(key)
+        raise InvalidProof, 'jti replayed'
+      end
+      Rails.cache.write(key, true, expires_in: JTI_TTL)
+    end
+
+    def canonical_url(url)
+      return nil if url.blank?
+      uri = URI.parse(url.to_s)
+      uri.fragment = nil
+      uri.query = nil
+      uri.to_s
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,4 +75,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.hosts << "web"
+  config.hosts << "host.docker.internal"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,4 +72,8 @@ Rails.application.routes.draw do
   scope path: '.well-known' do
     get 'jwks', to: 'well_knowns#jwks'
   end
+
+  namespace 'oauth2' do
+    post 'token', to: 'token#exchange'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,5 +75,6 @@ Rails.application.routes.draw do
 
   namespace 'oauth2' do
     post 'token', to: 'token#exchange'
+    match 'token', to: 'token#preflight', via: [:options]
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     stdin_open: true
     environment:
       PROMISE_KEY_REGISTRY_API_ROOT: http://promise_kms:3000/api/secret
+      PROMISE_ISSUER: http://web:3000
       RAILS_ENV: development
       NODE_ENV: development
       RAILS_BIND: 0.0.0.0

--- a/test/controllers/oauth2/token_controller_test.rb
+++ b/test/controllers/oauth2/token_controller_test.rb
@@ -1,0 +1,152 @@
+require 'test_helper'
+
+class Oauth2::TokenControllerTest < ActionDispatch::IntegrationTest
+  GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token-exchange'.freeze
+  ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token'.freeze
+  TOKEN_URL = 'http://www.example.com/oauth2/token'.freeze
+
+  setup do
+    Trust::Certificate.rotate!
+    @id_token = Authentication::IdToken.new(
+      sub: 'user-abc',
+      aud: 'example.com',
+      jti: SecureRandom.uuid
+    ).to_s
+    @device_key = OpenSSL::PKey::EC.generate('prime256v1')
+    @device_jwk = JSON::JWK.new(@device_key).as_json.slice('kty', 'crv', 'x', 'y')
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  teardown do
+    Rails.cache = @original_cache
+  end
+
+  test 'exchanges an id_token for a DPoP-bound access token' do
+    post_token(dpop: dpop_proof)
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal 'Bearer', body['token_type']
+    assert_equal 'urn:ietf:params:oauth:token-type:access_token', body['issued_token_type']
+    assert_equal 120, body['expires_in']
+
+    key = Trust::Certificate.current.public_key
+    decoded, header = JWT.decode(body['access_token'], key, true, { algorithm: 'ES512' })
+
+    assert header['kid'], 'access token must include kid'
+    assert_equal 'https://api.oase.app', decoded['aud']
+    assert_equal 'user-abc', decoded['sub']
+    assert_equal 'https://promiseauthentication.org', decoded['iss']
+    assert decoded['exp'] > decoded['iat']
+    assert decoded['jti']
+    assert_equal JSON::JWK.new(@device_key).thumbprint, decoded.dig('cnf', 'jkt')
+  end
+
+  test 'issued access token verifies against published JWKS' do
+    post_token(dpop: dpop_proof)
+    access_token = JSON.parse(response.body)['access_token']
+
+    get '/.well-known/jwks.json'
+    jwks = JSON.parse(response.body)
+
+    decoded, _header = JWT.decode(
+      access_token,
+      nil,
+      true,
+      algorithms: ['ES512'],
+      jwks: { keys: jwks['keys'] }
+    )
+
+    assert_equal 'user-abc', decoded['sub']
+  end
+
+  test 'rejects an invalid subject_token' do
+    post_token(dpop: dpop_proof, subject_token: 'not-a-jwt')
+
+    assert_response :bad_request
+    assert_equal 'invalid_grant', JSON.parse(response.body)['error']
+  end
+
+  test 'rejects request with missing audience' do
+    post_token(dpop: dpop_proof, audience: nil)
+
+    assert_response :bad_request
+    body = JSON.parse(response.body)
+    assert_equal 'invalid_request', body['error']
+    assert_match(/audience/, body['error_description'])
+  end
+
+  test 'rejects request with unsupported grant_type' do
+    post_token(dpop: dpop_proof, grant_type: 'authorization_code')
+
+    assert_response :bad_request
+    assert_equal 'invalid_request', JSON.parse(response.body)['error']
+  end
+
+  test 'rejects request with unsupported subject_token_type' do
+    post_token(dpop: dpop_proof, subject_token_type: 'urn:ietf:params:oauth:token-type:access_token')
+
+    assert_response :bad_request
+    assert_equal 'invalid_request', JSON.parse(response.body)['error']
+  end
+
+  test 'rejects request with missing DPoP header' do
+    post_token(dpop: nil)
+
+    assert_response :bad_request
+    assert_equal 'invalid_dpop_proof', JSON.parse(response.body)['error']
+  end
+
+  test 'rejects DPoP proof with wrong htm' do
+    proof = dpop_proof(htm: 'GET')
+    post_token(dpop: proof)
+
+    assert_response :bad_request
+    assert_equal 'invalid_dpop_proof', JSON.parse(response.body)['error']
+  end
+
+  test 'rejects DPoP proof with wrong htu' do
+    proof = dpop_proof(htu: 'https://elsewhere.example/oauth2/token')
+    post_token(dpop: proof)
+
+    assert_response :bad_request
+    assert_equal 'invalid_dpop_proof', JSON.parse(response.body)['error']
+  end
+
+  test 'rejects replayed DPoP jti' do
+    proof = dpop_proof
+    post_token(dpop: proof)
+    assert_response :success
+
+    post_token(dpop: proof)
+    assert_response :bad_request
+    assert_equal 'invalid_dpop_proof', JSON.parse(response.body)['error']
+  end
+
+  private
+
+  def post_token(dpop:, subject_token: @id_token, subject_token_type: ID_TOKEN_TYPE, grant_type: GRANT_TYPE, audience: 'https://api.oase.app')
+    params = {
+      grant_type: grant_type,
+      subject_token: subject_token,
+      subject_token_type: subject_token_type
+    }
+    params[:audience] = audience unless audience.nil?
+
+    headers = {}
+    headers['DPoP'] = dpop if dpop
+
+    post '/oauth2/token', params: params, headers: headers
+  end
+
+  def dpop_proof(htm: 'POST', htu: TOKEN_URL, iat: Time.now.to_i, jti: SecureRandom.uuid)
+    JWT.encode(
+      { htm: htm, htu: htu, iat: iat, jti: jti },
+      @device_key,
+      'ES256',
+      typ: 'dpop+jwt',
+      jwk: @device_jwk
+    )
+  end
+end

--- a/test/domain/dpop/proof_test.rb
+++ b/test/domain/dpop/proof_test.rb
@@ -1,0 +1,127 @@
+require 'test_helper'
+
+class Dpop::ProofTest < ActiveSupport::TestCase
+  HTM = 'POST'.freeze
+  HTU = 'https://promise.example/oauth2/token'.freeze
+
+  setup do
+    @key = OpenSSL::PKey::EC.generate('prime256v1')
+    @jwk = JSON::JWK.new(@key).as_json.slice('kty', 'crv', 'x', 'y')
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  teardown do
+    Rails.cache = @original_cache
+  end
+
+  test 'verifies a well-formed proof and exposes jkt + jti' do
+    jti = SecureRandom.uuid
+    token = sign_proof(payload: { htm: HTM, htu: HTU, iat: Time.now.to_i, jti: jti })
+
+    proof = Dpop::Proof.verify!(token, http_method: HTM, http_url: HTU)
+
+    assert_equal jti, proof.jti
+    assert_equal JSON::JWK.new(@key).thumbprint, proof.jkt
+  end
+
+  test 'rejects a missing header' do
+    error = assert_raises(Dpop::Proof::InvalidProof) do
+      Dpop::Proof.verify!(nil, http_method: HTM, http_url: HTU)
+    end
+    assert_match(/missing/i, error.message)
+  end
+
+  test 'rejects wrong typ' do
+    token = sign_proof(payload: { htm: HTM, htu: HTU, iat: Time.now.to_i, jti: SecureRandom.uuid }, typ: 'jwt')
+
+    assert_raises(Dpop::Proof::InvalidProof) do
+      Dpop::Proof.verify!(token, http_method: HTM, http_url: HTU)
+    end
+  end
+
+  test 'rejects wrong htm' do
+    token = sign_proof(payload: { htm: 'GET', htu: HTU, iat: Time.now.to_i, jti: SecureRandom.uuid })
+
+    error = assert_raises(Dpop::Proof::InvalidProof) do
+      Dpop::Proof.verify!(token, http_method: HTM, http_url: HTU)
+    end
+    assert_match(/htm/, error.message)
+  end
+
+  test 'rejects wrong htu' do
+    token = sign_proof(payload: { htm: HTM, htu: 'https://elsewhere.example/oauth2/token', iat: Time.now.to_i, jti: SecureRandom.uuid })
+
+    error = assert_raises(Dpop::Proof::InvalidProof) do
+      Dpop::Proof.verify!(token, http_method: HTM, http_url: HTU)
+    end
+    assert_match(/htu/, error.message)
+  end
+
+  test 'tolerates htu with query/fragment' do
+    token = sign_proof(payload: { htm: HTM, htu: "#{HTU}?foo=bar#frag", iat: Time.now.to_i, jti: SecureRandom.uuid })
+
+    assert_nothing_raised do
+      Dpop::Proof.verify!(token, http_method: HTM, http_url: "#{HTU}?baz=1")
+    end
+  end
+
+  test 'rejects iat too far in the past' do
+    token = sign_proof(payload: { htm: HTM, htu: HTU, iat: Time.now.to_i - 600, jti: SecureRandom.uuid })
+
+    assert_raises(Dpop::Proof::InvalidProof) do
+      Dpop::Proof.verify!(token, http_method: HTM, http_url: HTU)
+    end
+  end
+
+  test 'rejects iat too far in the future' do
+    token = sign_proof(payload: { htm: HTM, htu: HTU, iat: Time.now.to_i + 600, jti: SecureRandom.uuid })
+
+    assert_raises(Dpop::Proof::InvalidProof) do
+      Dpop::Proof.verify!(token, http_method: HTM, http_url: HTU)
+    end
+  end
+
+  test 'rejects missing jti' do
+    token = sign_proof(payload: { htm: HTM, htu: HTU, iat: Time.now.to_i })
+
+    assert_raises(Dpop::Proof::InvalidProof) do
+      Dpop::Proof.verify!(token, http_method: HTM, http_url: HTU)
+    end
+  end
+
+  test 'rejects replayed jti within TTL' do
+    jti = SecureRandom.uuid
+    token = sign_proof(payload: { htm: HTM, htu: HTU, iat: Time.now.to_i, jti: jti })
+
+    Dpop::Proof.verify!(token, http_method: HTM, http_url: HTU)
+
+    assert_raises(Dpop::Proof::InvalidProof) do
+      Dpop::Proof.verify!(token, http_method: HTM, http_url: HTU)
+    end
+  end
+
+  test 'rejects signature signed by a different key' do
+    forged_key = OpenSSL::PKey::EC.generate('prime256v1')
+    payload = { htm: HTM, htu: HTU, iat: Time.now.to_i, jti: SecureRandom.uuid }
+    # JWK header claims our key, but token is signed by forged_key
+    token = JWT.encode(payload, forged_key, 'ES256', typ: 'dpop+jwt', jwk: @jwk)
+
+    assert_raises(Dpop::Proof::InvalidProof) do
+      Dpop::Proof.verify!(token, http_method: HTM, http_url: HTU)
+    end
+  end
+
+  test 'jkt matches RFC 7638 thumbprint of embedded jwk' do
+    token = sign_proof(payload: { htm: HTM, htu: HTU, iat: Time.now.to_i, jti: SecureRandom.uuid })
+
+    proof = Dpop::Proof.verify!(token, http_method: HTM, http_url: HTU)
+    assert_equal JSON::JWK.new(@key).thumbprint, proof.jkt
+  end
+
+  private
+
+  def sign_proof(payload:, typ: 'dpop+jwt', alg: 'ES256', jwk: @jwk, key: @key)
+    JWT.encode(payload, key, alg, typ: typ, jwk: jwk)
+  end
+end


### PR DESCRIPTION
## Summary

Adds an `/oauth2/token` endpoint that swaps a long-lived id_token for a short-lived, audience-scoped access token bound to a client-supplied DPoP key (RFC 9449 `cnf.jkt`). Lets a relying party use Promise as a token issuer for multiple resource servers without forwarding the original id_token everywhere.

## What's in this PR

- **Token exchange controller** (`Oauth2::TokenController`): RFC 8693 grant_type with `urn:ietf:params:oauth:token-type:id_token` as the subject token type. Verifies the DPoP proof's `htm`/`htu` against the request, then mints an ES512 access token (~2-min TTL) with the audience requested by the caller and a `cnf.jkt` claim copying the proof's JWK thumbprint.
- **Configurable issuer**: `ISSUER` constant now reads `ENV.fetch('PROMISE_ISSUER', 'https://promiseauthentication.org')` in both the token controller and `Authentication::IdToken#payload`. Defaults unchanged in production.
- **Dev hosts**: `web` and `host.docker.internal` added to `config.hosts` so downstream services on a shared docker network can pull `/.well-known/jwks.json` without tripping Rails' host authorization.
- **CORS**: the token endpoint now answers OPTIONS preflight and stamps `Access-Control-Allow-*` headers (Promise does not run `rack-cors`, so handled inline on the controller).
- **docker-compose.yml**: sets `PROMISE_ISSUER=http://web:3000` so locally minted tokens carry an `iss` reachable from inside the shared docker network.

## Test plan

- [ ] Existing test suite passes.
- [ ] Cross-origin `POST /oauth2/token` preflight returns the expected CORS headers.
- [ ] `iss` claim on issued tokens reflects `PROMISE_ISSUER` when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)