### PR TITLE
✏️ Steer people toward their lifelong personal e-mail

### DIFF
--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -32,7 +32,10 @@
             <% end %>
           </div>
           <p class="input-label">
-            E-mail
+            <%= t '.email_label' %>
+          </p>
+          <p class="text-secondary text-xs mb-2">
+            <%= t '.email_label_help_html' %>
           </p>
           <%= email_field_tag :email, @email_validator&.replacement || registration_configuration[:email], class: 'login-input' + (!@email_validator || @email_validator.valid? ? '' : ' with-error'), autofocus: true, required: true, tabindex: 1 %>
           <p class="text-secondary text-xs mt-1">

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -50,9 +50,11 @@ da:
       enter_credentials_html: "%{name} bruger Promise til at logge ind. Angiv den e-mail du vil logge ind på Promise med."
       we_could_not_send_email_html: "Vi kunne ikke sende en e-mail til <strong>%{email}</strong>. Tjek venligst at du har skrevet den rigtigt. Her er beskeden vi har fået: <em class='font-mono'>%{message}</em>."
       redirect_to_dashboard: Du vil blive sendt videre til dit overblik.
+      email_label: Din personlige e-mail
+      email_label_help_html: Brug den e-mail, du regner med at <strong>beholde resten af livet</strong> — ikke en arbejds-, skole- eller studiemail.
       we_save_no_data_html: Din e-mail bliver <em class="whitespace-nowrap">ikke gemt</em> i et læsbart format.
-      what_email_question: Hvilken e-mail skal jeg bruge?
-      what_email_help: Brug den e-mail, der identificerer dig som menneske — din personlige. Undgå delte, arbejdsrelaterede eller rollebaserede adresser (som info@ eller team@). Du skal bruge denne e-mail hver gang du logger ind.
+      what_email_question: Hvorfor skal det være min personlige e-mail?
+      what_email_help: Din e-mail er det, der identificerer dig som menneske her, og du skal bruge den hver gang du logger ind. Arbejds-, skole- og studiemails bliver taget fra dig, når du skifter job eller bliver færdig, og delte eller rollebaserede adresser (som info@ eller team@) tilhører en organisation og ikke dig — den dag du mister adgangen til den indbakke, kan du ikke længere modtage din login-kode. Du kan skifte e-mail senere, mens du er logget ind, men da vi aldrig gemmer den i et læsbart format, kan vi ikke hjælpe dig med at få kontoen tilbage, hvis du mister adgangen først. Så vælg den e-mail, der følger dig hele livet.
       child_account_question: Jeg opretter en konto til mit barn
       child_account_help_html: Hvis dit barn ikke har sin egen e-mail, kan du bruge <code class="bg-white px-1 rounded">ditnavn+barnetsnavn@gmail.com</code>-tricket. De fleste udbydere (Gmail, Outlook, iCloud, Fastmail og flere) ignorerer alt mellem <code>+</code> og <code>@</code>, så mailen lander stadig i din egen indbakke — men tæller som en unik e-mail her. På den måde kan du styre dit barns konto uden at oprette en ny mailkonto.
       did_you_mean_html: Vi har rettet din mail fra %{old_email} til <strong>%{email}</strong>. Er det korrekt? Ellers kan du rette den igen og fortsætte.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,9 +52,11 @@ en:
       redirect_to_dashboard: You will be redirected to your dashboard.
       go_on: Go
       going_html: 'Please wait&hellip;'
+      email_label: Your personal e-mail
+      email_label_help_html: Use the e-mail you expect to <strong>keep for the rest of your life</strong> — not a work, school or study address.
       we_save_no_data_html: Your e-mail will <em class="whitespace-nowrap">not be saved</em> in a readable format.
-      what_email_question: What e-mail should I use?
-      what_email_help: Use the e-mail that identifies you as a human being — your personal one. Avoid shared, work or role-based addresses (like info@ or team@). You will use this e-mail every time you sign in.
+      what_email_question: Why does it have to be my personal e-mail?
+      what_email_help: Your e-mail is what identifies you as a human being here, and you will use it every time you sign in. Work, school and study addresses are taken away from you when you change job or graduate, and shared or role-based addresses (like info@ or team@) belong to an organisation rather than to you — the day you lose access to that inbox, you can no longer receive your sign-in code. You can change your e-mail later while you are signed in, but because we never store it in a readable format, we cannot recover the account for you if you lose access first. So pick the e-mail that will follow you through life.
       child_account_question: I'm creating an account for my child
       child_account_help_html: If your child doesn't have their own e-mail, you can use the <code class="bg-white px-1 rounded">yourname+childsname@gmail.com</code> trick. Most providers (Gmail, Outlook, iCloud, Fastmail and more) ignore everything between the <code>+</code> and the <code>@</code>, so the e-mail still lands in your own inbox — but it counts as a unique e-mail here. That way you can manage your child's account without creating a separate mailbox.
       did_you_mean_html: We changed your email from %{old_email} to <strong>%{email}</strong>. Is that correct? Otherwise, please change it back, and continue.


### PR DESCRIPTION
## Why

The guidance about *which* e-mail to use only lived behind a collapsed `<details>` on `/login`, so most people never opened it before typing an address. Since the e-mail is never stored in a readable format, picking a work or school address that later disappears is a real path to losing the account.

## What

- **Label is now the instruction** — "E-mail" → "Your personal e-mail" / "Din personlige e-mail".
- **Always-visible hint above the input** — use the e-mail you expect to *keep for the rest of your life*, not a work, school or study address.
- **Reworded the disclosure** from "What e-mail should I use?" to "Why does it have to be my personal e-mail?", so it answers the question the new label raises rather than asking one. The body now explains the mechanism: work/school/study addresses are taken away when you change job or graduate, role addresses (`info@`, `team@`) belong to an organisation, and the day you lose that inbox you can't receive your sign-in code. It also states plainly that you *can* change the e-mail while signed in, but that we can't recover the account once access is lost.

Both EN and DA. `enter_credentials_html` deliberately left unchanged in both languages.

## Notes

Copy + one view change, no logic touched. Not verified in a running app — both locale files parse and all new keys (`email_label`, `email_label_help_html`) exist in EN and DA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)