### PR TITLE
💄 Current year in footer, "eller" divider in mail, no human-check flash on Turnstile auto-pass

### DIFF
--- a/app/controllers/concerns/turnstile_concern.rb
+++ b/app/controllers/concerns/turnstile_concern.rb
@@ -7,10 +7,14 @@ module TurnstileConcern
     helper_method :turnstile_tag_html
   end
 
-  def turnstile_tag_html
-    "<div class=\"cf-turnstile\" data-callback=\"onSuccess\" data-theme=\"light\" data-sitekey=\"#{ENV.fetch(
-      'PROMISE_CLOUDFLARE_TURNSTILE_SITE_KEY', '3x00000000000000000000FF'
-    )}\"></div>".html_safe
+  def turnstile_tag_html(appearance: nil, before_interactive: nil)
+    attrs = { class: 'cf-turnstile',
+              'data-callback': 'onSuccess',
+              'data-theme': 'light',
+              'data-sitekey': ENV.fetch('PROMISE_CLOUDFLARE_TURNSTILE_SITE_KEY', '3x00000000000000000000FF'),
+              'data-appearance': appearance,
+              'data-before-interactive-callback': before_interactive }.compact
+    helpers.tag.div(**attrs)
   end
 
   def pre_validated?

--- a/app/views/email_verification_mailer/verify_email.html.erb
+++ b/app/views/email_verification_mailer/verify_email.html.erb
@@ -12,6 +12,13 @@
       <%= @magic_link_label %>
     </a>
   </p>
+  <table role="presentation" width="100%" style="margin:30px 0;border-collapse:collapse;">
+    <tr>
+      <td style="vertical-align:middle;"><div style="border-top:1px solid #d1d5db;"></div></td>
+      <td style="width:1%;padding:0 12px;font-family:sans-serif;font-style:italic;color:#6b7280;white-space:nowrap;"><%= t('.or') %></td>
+      <td style="vertical-align:middle;"><div style="border-top:1px solid #d1d5db;"></div></td>
+    </tr>
+  </table>
 <% end %>
 
 <p style="margin: 0;padding:0;font-family:sans-serif;font-weight:bold;">

--- a/app/views/email_verification_mailer/verify_email.text.erb
+++ b/app/views/email_verification_mailer/verify_email.text.erb
@@ -8,6 +8,8 @@
 <%= t('.magic_link_intro') %>
 <%= @magic_link_url %>
 
+--------- <%= t('.or') %> ---------
+
 <%= t('.magic_link_or_code') %> <%= @code %>
 <% else %>
 <%= t('.code') %> <%= @code %>

--- a/app/views/registrations/verify_human.html.erb
+++ b/app/views/registrations/verify_human.html.erb
@@ -1,8 +1,12 @@
 <%= content_for :body do %>
+  <%# No greeting when navigating backwards (e.g. "Send ny kode" on
+      verify_email) — back_to links land here with the slide-from-left
+      flash set by move_back. %>
+  <% celebrate = request.get? && flash[:slide_class] != 'a-slide-in-from-left' %>
   <%= form_tag verify_human_registrations_path(registration_configuration), class: 'w-full flex-1' do %>
-    <div class="w-full flex items-center flex-col">
+    <div class="humanflow <%= 'play' if celebrate %> w-full flex items-center flex-col">
       <div class="flex flex-1 flex-row justify-between border-b pb-3 mb-5 w-full pt-8 items-center">
-        <h2 class="text-lg text-primary font-bold leading-none">
+        <h2 class="check-title text-lg text-primary font-bold leading-none">
           <%= t('.title', email: registration_configuration[:email]) %>
         </h2>
         <a href="javascript:void(toggleDescription());" class="flex flex-row items-center space-x-1">
@@ -13,12 +17,15 @@
         </a>
       </div>
 
-      <%# Two-screen flow: the "you're new here" greeting (badge pops in,
-          sparkles twinkle, ring pulses) shows alone, then slides out left
-          while the human-check slides in from the right. Both screens
-          share one grid cell so the card keeps its height. The show is
-          skipped on re-render after a failed Turnstile check, and with
-          reduced motion the two screens simply stack, static. %>
+      <%# Event-driven two-screen flow: the "you're new here" greeting
+          (badge pops in, sparkles twinkle, ring pulses) shows while
+          Turnstile decides. If it auto-passes, the form submits straight
+          from the greeting and the human-check text is never shown
+          (appearance=interaction-only keeps the widget invisible too).
+          Only when Turnstile asks for interaction — or on the fallback
+          timeout — does the check screen slide in. The greeting is
+          skipped on re-render after a failed check, and with reduced
+          motion the two screens simply stack, static. %>
       <style>
         @media (prefers-reduced-motion: no-preference) {
           .newbie-badge { animation: newbie-pop .5s cubic-bezier(.22, 1.61, .36, 1) both, newbie-ring .9s ease-out .45s both; }
@@ -26,10 +33,14 @@
           /* clip, not hidden: a hidden box is still programmatically
              scrollable, so focus landing in the (offscreen) second screen
              would scroll the whole show out of sight. */
-          .screens.play { display: grid; overflow: hidden; overflow: clip; }
-          .screens.play > * { grid-area: 1 / 1; min-width: 0; }
-          .screens.play .screen-celebrate { align-self: center; animation: screen-out .45s ease-in 2.2s both; }
-          .screens.play .screen-check { animation: screen-in .5s ease-out 2.35s both; }
+          .humanflow.play .screens { display: grid; overflow: hidden; overflow: clip; }
+          .humanflow.play .screens > * { grid-area: 1 / 1; min-width: 0; }
+          .humanflow.play .screen-celebrate { align-self: center; }
+          .humanflow.play:not(.advance) .screen-check { opacity: 0; visibility: hidden; }
+          .humanflow.play:not(.advance) .check-title { opacity: 0; }
+          .humanflow.play.advance .screen-celebrate { animation: screen-out .45s ease-in both; }
+          .humanflow.play.advance .screen-check { animation: screen-in .5s ease-out .15s both; }
+          .humanflow.play.advance .check-title { animation: title-in .4s ease-out .3s both; }
           @keyframes newbie-pop {
             0% { transform: scale(0); }
             100% { transform: scale(1); }
@@ -43,6 +54,10 @@
             30% { transform: scale(1.25) rotate(-8deg); }
             60% { transform: scale(.95) rotate(6deg); }
           }
+          @keyframes title-in {
+            from { opacity: 0; }
+            to { opacity: 1; }
+          }
           @keyframes screen-out {
             from { transform: translateX(0); opacity: 1; }
             to { transform: translateX(-110%); opacity: 0; visibility: hidden; }
@@ -53,23 +68,47 @@
           }
         }
       </style>
-      <%# No greeting when navigating backwards (e.g. "Send ny kode" on
-          verify_email) — back_to links land here with the slide-from-left
-          flash set by move_back. %>
-      <% celebrate = request.get? && flash[:slide_class] != 'a-slide-in-from-left' %>
       <script>
-        // Turnstile (test mode) can succeed before the greeting has
-        // finished — hold the auto-submit until the check has slid in,
-        // so the show isn't cut short by a mid-animation navigation.
-        var showDone = !(<%= celebrate %> && matchMedia('(prefers-reduced-motion: no-preference)').matches);
+        // Turnstile decides how this page plays out. During the greeting
+        // we hold both outcomes: auto-pass submits as soon as the greeting
+        // has had its moment; a challenge reveals the check screen. The
+        // fallback advance covers Turnstile staying silent (script blocked,
+        // network trouble), so the user is never stuck on the greeting.
+        var playing = <%= celebrate %> && matchMedia('(prefers-reduced-motion: no-preference)').matches;
+        var greetingDone = !playing;
         var pendingSubmit = false;
-        document.addEventListener('animationend', function (e) {
-          if (e.animationName !== 'screen-in') return;
-          showDone = true;
-          if (pendingSubmit) document.getElementById('submit_button').click();
-        });
+        var pendingAdvance = false;
+        var submitted = false;
+
+        function submitHuman() {
+          submitted = true;
+          document.getElementById('submit_button').click();
+        }
+        function advanceToCheck() {
+          var flow = document.querySelector('.humanflow');
+          if (flow) flow.classList.add('advance');
+        }
+        if (playing) {
+          setTimeout(function () {
+            greetingDone = true;
+            if (pendingSubmit) { submitHuman(); } else if (pendingAdvance) { advanceToCheck(); }
+          }, 2200);
+          setTimeout(function () {
+            if (!submitted && !pendingSubmit) advanceToCheck();
+          }, 6000);
+        }
+        function onTurnstileInteractive() {
+          if (greetingDone) { advanceToCheck(); } else { pendingAdvance = true; }
+        }
+        function onSuccess(token) {
+          document.getElementById('submit_button').disabled = false;
+          // Remove class that makes it look disabled
+          document.getElementById('submit_button').classList.remove('opacity-50');
+          document.getElementById('submit_button').classList.remove('scale-0');
+          if (greetingDone) { submitHuman(); } else { pendingSubmit = true; }
+        }
       </script>
-      <div class="screens <%= 'play' if celebrate %> w-full">
+      <div class="screens w-full">
         <% if celebrate %>
           <div class="screen-celebrate w-full flex flex-col items-center pt-2 text-center">
             <span class="newbie-badge relative flex h-14 w-14 items-center justify-center rounded-full bg-amber-100">
@@ -96,20 +135,7 @@
           </p>
           <div class="w-full flex flex-col mt-6 pb-4">
             <div class="w-full h-24 flex items-center justify-end">
-                <script>
-                  function onSuccess(token) {
-                    document.getElementById('submit_button').disabled = false;
-                    // Remove class that makes it look disabled
-                    document.getElementById('submit_button').classList.remove('opacity-50');
-                    document.getElementById('submit_button').classList.remove('scale-0');
-                    if (showDone) {
-                      document.getElementById('submit_button').click();
-                    } else {
-                      pendingSubmit = true;
-                    }
-                  }
-                </script>
-              <%= turnstile_tag_html %>
+              <%= turnstile_tag_html(appearance: 'interaction-only', before_interactive: 'onTurnstileInteractive') %>
             </div>
             <div class="flex w-full justify-end items-center mt-0">
               <%= back_to(registration_configuration) do |args| new_registration_path(args) end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -26,7 +26,7 @@
 
 <footer class="text-center text-xs text-secondary mt-3 mb-6">
   <span class="tracking-wide">
-    <%= link_to name, root_path %> - 2025
+    <%= link_to name, root_path %> - <%= Time.current.year %>
     <% if logged_in? && !relying_party %>
       - <%= link_to t('.change_password'), edit_password_path, class: 'underline' %>
       - <%= link_to t('.change_email'), edit_email_path, class: 'underline' %>

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -204,6 +204,7 @@ da:
       magic_link_button: "Bekræft e-mail og fortsæt"
       magic_link_button_with_client: "Bekræft e-mail og fortsæt til %{client}"
       magic_link_intro: "Bekræft din e-mail og fortsæt ved at klikke på linket herunder:"
+      or: eller
       magic_link_or_code: "Vil du fortsætte, der hvor du slap? Så indtast denne kode dér i stedet:"
       what_is_promise:
         title: Hvad er Promise?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -204,6 +204,7 @@ en:
       magic_link_button: "Confirm e-mail and continue"
       magic_link_button_with_client: "Confirm e-mail and continue to %{client}"
       magic_link_intro: "Confirm your e-mail and continue by clicking the link below:"
+      or: or
       magic_link_or_code: "Want to continue where you left off? Enter this code there instead:"
       what_is_promise:
         title: What is Promise?


### PR DESCRIPTION
Three small UX fixes:

- **Footer**: the year is rendered from the clock instead of the hardcoded 2025.
- **Verification mail**: the button and the code are now separated by the same "—— eller ——" divider as on the verify_email page, in both the HTML and text parts (the on-page mail mockup picks it up automatically).
- **verify_human**: Cloudflare Turnstile frequently auto-passes, which made the "Er du et menneske?" text flash by pointlessly. The widget now uses `appearance=interaction-only` plus `before-interactive-callback`: on auto-pass the form submits straight from the "Du er ny her" greeting and the human-check text is never shown; the check screen and title only slide in when the challenge actually requires interaction (or after a 6s fallback if Turnstile stays silent). Reduced-motion and failed-check re-renders keep the static layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)