### PR TITLE
✨ Registration-funnel page under /root/funnel

### DIFF
--- a/app/controllers/root/funnel_controller.rb
+++ b/app/controllers/root/funnel_controller.rb
@@ -1,0 +1,24 @@
+class Root::FunnelController < RootController
+  STEPS = %w[started human_verified mail_sent confirmed_code confirmed_magic_link password_created].freeze
+
+  def show
+    events = Ahoy::Event.where(name: 'registration_step')
+
+    @windows = {
+      'Today' => Time.current.beginning_of_day,
+      '7 days' => 7.days.ago,
+      '30 days' => 30.days.ago,
+      'All time' => nil
+    }
+
+    @counts = @windows.transform_values do |since|
+      scope = since ? events.where(time: since..) : events
+      scope.group(Arel.sql("properties ->> 'step'")).count
+    end
+
+    @resends = @windows.transform_values do |since|
+      scope = since ? events.where(time: since..) : events
+      scope.where("properties ->> 'resend' = 'true'").count
+    end
+  end
+end

--- a/app/views/root/funnel/show.html.erb
+++ b/app/views/root/funnel/show.html.erb
@@ -1,0 +1,51 @@
+<div class="max-w-2xl p-4 m-auto space-y-4">
+  <h1 class="text-xl font-black text-center mt-12">
+    Registration funnel
+  </h1>
+
+  <table class="w-full text-sm">
+    <thead>
+      <tr class="border-b text-left">
+        <th class="py-2 pr-2">Step</th>
+        <% @windows.each_key do |label| %>
+          <th class="py-2 px-2 text-right"><%= label %></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% Root::FunnelController::STEPS.each do |step| %>
+        <tr class="border-b border-gray-100 <%= 'font-bold' if step == 'password_created' %>">
+          <td class="py-2 pr-2 font-mono"><%= step %></td>
+          <% @windows.each_key do |label| %>
+            <% count = @counts[label][step] || 0 %>
+            <% started = @counts[label]['started'] || 0 %>
+            <td class="py-2 px-2 text-right tabular-nums">
+              <%= count %>
+              <% if step != 'started' && started.positive? %>
+                <span class="text-secondary text-xs">(<%= (100.0 * count / started).round %>%)</span>
+              <% end %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+      <tr class="text-secondary">
+        <td class="py-2 pr-2 font-mono">↳ of which resends</td>
+        <% @windows.each_key do |label| %>
+          <td class="py-2 px-2 text-right tabular-nums"><%= @resends[label] %></td>
+        <% end %>
+      </tr>
+    </tbody>
+  </table>
+
+  <p class="text-secondary text-sm">
+    Server-side Ahoy events, one per step — no e-mail or other personal
+    data is recorded. Percentages are relative to <span class="font-mono">started</span>
+    in the same window. Steps can exceed <span class="font-mono">started</span>
+    when a flow resumes across windows or a mail is resent.
+    Tracking live since 2026-08-12.
+  </p>
+
+  <p class="text-center">
+    <%= link_to '&larr; Relying parties'.html_safe, root_relying_parties_path %>
+  </p>
+</div>

--- a/app/views/root/relying_parties/index.html.erb
+++ b/app/views/root/relying_parties/index.html.erb
@@ -8,4 +8,7 @@
       Tokens generated for <strong><%= rp_id %></strong>:
     </h2>
   <% end %>
+  <p class="text-center">
+    <%= link_to 'Registration funnel &rarr;'.html_safe, root_funnel_path %>
+  </p>
 </div>

--- a/app/views/root/relying_parties/index.html.erb
+++ b/app/views/root/relying_parties/index.html.erb
@@ -3,9 +3,9 @@
   <h1 class="text-xl font-black text-center mt-12">
     Relying parties
   </h1>
-  <% Statistics::SignInEvent.pluck(:relying_party_id).uniq.each do |rp_id| %>
+  <% Statistics::SignInEvent.group(:relying_party_id).count.sort_by { |_, count| -count }.each do |rp_id, count| %>
     <h2 class="">
-      Tokens generated for <strong><%= rp_id %></strong>:
+      Tokens generated for <strong><%= rp_id %></strong>: <%= count %>
     </h2>
   <% end %>
   <p class="text-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
 
   namespace 'root' do
     get '/', to: 'relying_parties#index'
+    get 'funnel', to: 'funnel#show'
     resources :relying_parties, constraints: { id: %r{[^/]+} }, only: [:index]
   end
 

--- a/test/controllers/root/funnel_controller_test.rb
+++ b/test/controllers/root/funnel_controller_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class Root::FunnelControllerTest < ActionDispatch::IntegrationTest
+  test 'requires a signed-in root user' do
+    get '/root/funnel'
+    assert_redirected_to %r{/login}
+  end
+end


### PR DESCRIPTION
Adds the operator view over the `registration_step` events from #222:

- Table of funnel steps — `started` → `human_verified` → `mail_sent` → `confirmed_code` / `confirmed_magic_link` → `password_created` — for today / 7 days / 30 days / all time, with percentages relative to `started` and a resend count row.
- Lives in the `root` namespace behind the existing `PROMISE_ROOT_USER_IDS` gate (the `admin` namespace is the public getting-started area, so it deliberately does not live there).
- Linked from the root relying-parties page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)