### PR TITLE
Stale verify_email tab follows the flow when it finishes elsewhere

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -74,11 +74,7 @@ class RegistrationsController < ApplicationController
   def verify_email
     @code = email_verifier.verifier
 
-    if @code.nil?
-      return redirect_to(confirm_path(login_configuration)) if logged_in?
-
-      return redirect_to login_path(registration_configuration)
-    end
+    return redirect_to stale_flow_destination if @code.nil?
     return unless request.post?
 
     if verify_email_verification_code!
@@ -96,6 +92,18 @@ class RegistrationsController < ApplicationController
     else
       flash.now[:error] = I18n.t('too_many_codes_sent')
       render action: :verify_email
+    end
+  end
+
+  # Polled by the verify_email page so a tab parked there follows the
+  # flow when it completes elsewhere (e.g. the mail link opened in
+  # another browser). Reveals nothing the create action doesn't already:
+  # posting an email there also branches on whether the account exists.
+  def status
+    if email_verifier.verifier
+      head :no_content
+    else
+      render json: { redirect_to: stale_flow_destination(celebrate: '0') }
     end
   end
 
@@ -156,6 +164,21 @@ class RegistrationsController < ApplicationController
       # Lets the confirm page play its account-created celebration once.
       flash[:registered] = true
       redirect_to confirm_path(login_configuration)
+    end
+  end
+
+  # Where a session parked on verify_email should go once its code is
+  # gone: the flow finished (possibly in another browser, via the mail
+  # link) or the code expired. If the account now exists, land on the
+  # password prompt instead of the start of the flow.
+  def stale_flow_destination(extra = {})
+    return confirm_path(login_configuration) if logged_in?
+
+    configuration = registration_configuration(:email_verification_code)
+    if ::Authentication::Services::Authenticate::Existing.known?(configuration[:email])
+      verify_password_path(configuration.to_h.merge(extra))
+    else
+      login_path(configuration)
     end
   end
 

--- a/app/views/authentication/verify_password.html.erb
+++ b/app/views/authentication/verify_password.html.erb
@@ -55,7 +55,10 @@
           }
         }
       </style>
-      <% celebrate = flash[:password_message].blank? && flash[:email_message].blank? %>
+      <%# celebrate=0 arrives from a stale verify_email tab auto-following a
+          flow that finished in another browser — a quiet, machine-initiated
+          navigation that shouldn't replay the welcome-back show. %>
+      <% celebrate = flash[:password_message].blank? && flash[:email_message].blank? && params[:celebrate] != '0' %>
       <script>
         // Focus arrives only once the form has slid in — focusing the
         // still-offscreen field would scroll it into view prematurely.

--- a/app/views/registrations/verify_email.html.erb
+++ b/app/views/registrations/verify_email.html.erb
@@ -179,6 +179,31 @@
           window.addEventListener('resize', positionOpenMockupCursors);
           document.addEventListener('DOMContentLoaded', positionOpenMockupCursors);
           document.addEventListener('turbolinks:load', positionOpenMockupCursors);
+
+          // A tab parked here goes stale when the flow completes elsewhere
+          // (e.g. the mail link opened in another browser) or the code
+          // expires. Poll for that and move the tab along; celebrate=0 makes
+          // verify_password skip its welcome-back show on this quiet arrival.
+          window.verifyEmailStatusCheck = function () {
+            if (!document.getElementById('email_verification_code')) {
+              clearInterval(window.verifyEmailStatusPoller);
+              return;
+            }
+            fetch('<%== j status_registrations_path(registration_configuration(:email_verification_code)) %>', { headers: { Accept: 'application/json' } })
+              .then(function (response) { return response.status === 200 ? response.json() : null; })
+              .then(function (data) {
+                if (data && data.redirect_to) window.location.replace(data.redirect_to);
+              })
+              .catch(function () {});
+          };
+          if (window.verifyEmailStatusPoller) clearInterval(window.verifyEmailStatusPoller);
+          window.verifyEmailStatusPoller = setInterval(function () { window.verifyEmailStatusCheck(); }, 5000);
+          if (!window.verifyEmailStatusVisibilityHook) {
+            window.verifyEmailStatusVisibilityHook = true;
+            document.addEventListener('visibilitychange', function () {
+              if (!document.hidden) window.verifyEmailStatusCheck();
+            });
+          }
         </script>
         <div class="screens <%= 'play' if play_intro %> w-full">
           <% if play_intro %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
       post :verify_human
       get :verify_email
       post :verify_email
+      get :status
       get :create_password
       post :create_password
     end

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -67,6 +67,44 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
   #                                                          email_verification_code: code.code)
   # end
 
+  test 'status while the code is pending' do
+    Authentication::RelyingParty.stub :fetch, nil do
+      post verify_human_registrations_url, params: { email: 'hello@world.com' }
+      get status_registrations_url(email: 'hello@world.com', client_id: 'oase.app')
+      assert_response :no_content
+    end
+  end
+
+  test 'status once the flow finished elsewhere' do
+    Authentication::RelyingParty.stub :fetch, nil do
+      post verify_human_registrations_url, params: { email: 'hello@world.com' }
+      Authentication::Services::Authenticate.new(email: 'hello@world.com', password: 'secret').register!
+      EmailVerificationCode.find_by_cleartext('hello@world.com')&.destroy
+
+      get status_registrations_url(email: 'hello@world.com', client_id: 'oase.app')
+      assert_response :success
+      assert_equal verify_password_path(celebrate: '0', client_id: 'oase.app', email: 'hello@world.com'),
+                   response.parsed_body['redirect_to']
+    end
+  end
+
+  test 'status once the code expired without an account' do
+    Authentication::RelyingParty.stub :fetch, nil do
+      get status_registrations_url(email: 'hello@world.com', client_id: 'oase.app')
+      assert_response :success
+      assert_equal login_path(client_id: 'oase.app', email: 'hello@world.com'),
+                   response.parsed_body['redirect_to']
+    end
+  end
+
+  test 'stale verify_email redirects to password once the account exists' do
+    Authentication::RelyingParty.stub :fetch, nil do
+      Authentication::Services::Authenticate.new(email: 'hello@world.com', password: 'secret').register!
+      get verify_email_registrations_url(email: 'hello@world.com', client_id: 'oase.app')
+      assert_redirected_to verify_password_url(client_id: 'oase.app', email: 'hello@world.com')
+    end
+  end
+
   test 'handle wrong email' do
     email = 'hello@gmail.dk'
     # Let's mock the email sending:


### PR DESCRIPTION
## What

A tab parked on `verify_email` ("check your inbox") now notices when the registration finishes elsewhere — e.g. the mail link opened on the phone or in another browser — and moves itself along instead of sitting there forever.

- New `GET /registrations/status` endpoint: 204 while the code is pending; once it's gone, returns where the tab should go — `verify_password` if the account now exists, `confirm` if this session is already logged in, `login` if the code expired without an account. Reveals nothing the create action doesn't already (posting an email there also branches on account existence).
- The verify_email page polls it every 5s, plus immediately when the tab regains visibility, and navigates with `location.replace` so Back doesn't return to the dead page.
- The automatic arrival carries `celebrate=0`, which makes verify_password skip its welcome-back two-screen show (mirrors the confirm page's `celebrate=1` convention) — the password form is immediately visible and focused.
- A manual refresh of a stale verify_email page also lands on `verify_password` now, instead of the email-entry page.

## Why

The Oase app's external-browser handover work (oase-app/oase-app#468) highlighted that the initiating browser is left stranded on "check your inbox" when the flow completes elsewhere. This closes that gap web-side.

## Testing

- 4 new controller tests covering the endpoint's three states and the stale-page redirect; full suite green (113 runs, 0 failures).
- Verified live in dev: parked a tab on verify_email, destroyed the pending code (what completing registration does), tab moved itself to the password prompt within one poll, no animation, correct copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)