### PR TITLE
Don't strand desktop users on a custom-scheme app handoff

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -25,6 +25,13 @@ class AuthenticationController < ApplicationController
 
   def go_to
     if relying_party.present?
+      # A custom-scheme handoff on a device without the app dies silently
+      # (desktop browsers refuse the navigation), so don't burn a token on
+      # it — land on confirm, which explains how to continue in the app.
+      # authenticate funnels through here too, so this also covers an
+      # existing user signing in with the app's redirect_uri on desktop.
+      return redirect_to confirm_path(login_configuration) if custom_scheme_handoff? && !mobile_device?
+
       id_token = Authentication::Services::GetIdToken.new(
         user_id: current_user.id,
         relying_party_id: relying_party.id,
@@ -43,7 +50,12 @@ class AuthenticationController < ApplicationController
         login_configuration: login_configuration
       )
 
-      reset_session
+      # An app handoff via custom scheme may go nowhere (no app on this
+      # device — desktop browsers refuse the redirect outright), and the
+      # user's next press of the button must re-issue rather than bounce
+      # to login off a dead session. Web handoffs keep the forget-me-
+      # after-handoff behavior.
+      reset_session unless custom_scheme_handoff?
     else
       redirect_to dashboard_path
     end

--- a/app/controllers/concerns/relying_party_concern.rb
+++ b/app/controllers/concerns/relying_party_concern.rb
@@ -3,9 +3,34 @@ module RelyingPartyConcern
 
   included do
     helper_method :relying_party
+    helper_method :custom_scheme_handoff?
+    helper_method :mobile_device?
   end
 
   def relying_party
     @relying_party ||= ::Authentication::RelyingParty.find(params[:client_id])
+  end
+
+  # True when the final redirect hands the id_token to a native app via a
+  # custom URL scheme (e.g. oase://authenticate) rather than the web. Such
+  # a redirect only works on a device with the app installed — a desktop
+  # browser silently refuses it ("unknown protocol").
+  def custom_scheme_handoff?
+    # No redirect_uri param means the party's default_redirect_uri, which
+    # is always https — only an explicit param can name a custom scheme.
+    url = login_configuration[:redirect_uri]
+    return false if url.blank?
+
+    scheme = URI.parse(url).scheme
+    scheme.present? && !%w[http https].include?(scheme)
+  rescue URI::InvalidURIError
+    false
+  end
+
+  # Coarse on purpose: only used to pick copy/affordances for handoffs the
+  # current device plainly cannot perform. iPads in desktop mode report a
+  # Mac user agent and get the desktop treatment — acceptable.
+  def mobile_device?
+    request.user_agent.to_s.match?(/iPhone|iPad|iPod|Android/i)
   end
 end

--- a/app/views/authentication/confirm.html.erb
+++ b/app/views/authentication/confirm.html.erb
@@ -77,17 +77,36 @@
         <p class="text-secondary text-sm max-w-xs text-center mt-3">
           <%= t '.you_are_html', email: current_user.email, name: name %>
         </p>
-        <%= button_to go_to_path(login_configuration), class: "button primary my-10 flex items-center justify-center appearance-none", autofocus: !celebrate do %>
-          <span class="text-center">
-            <% if relying_party.supports_legacy_accounts? && current_user.data.id_for(relying_party.id).blank? %>
-              <%= t('.create_account_html', relying_party_name: relying_party.name) %>
-            <% else %>
-              <%= t('.go_to_html', relying_party_name: relying_party.name) %>
-            <% end %>
-          </span>
-          <span class="ml-3">
-            &rarr;
-          </span>
+        <% if custom_scheme_handoff? && !mobile_device? %>
+          <%# The final redirect targets the relying party's native app via
+              a custom URL scheme — this device can't open it (desktop
+              browsers refuse the navigation and the button would appear to
+              do nothing). Point the user back to the device the app lives
+              on instead. %>
+          <div class="my-10 w-full max-w-xs rounded-xl border border-blue-200 bg-blue-50 p-4 text-center">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="mx-auto h-7 w-7 text-blue-700">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 0 0 6 3.75v16.5a2.25 2.25 0 0 0 2.25 2.25h7.5A2.25 2.25 0 0 0 18 20.25V3.75a2.25 2.25 0 0 0-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3" />
+            </svg>
+            <p class="mt-2 font-semibold text-primary">
+              <%= t '.continue_in_app_html', relying_party_name: relying_party.name %>
+            </p>
+            <p class="mt-2 text-sm text-primary">
+              <%= t '.continue_in_app_help_html', relying_party_name: relying_party.name %>
+            </p>
+          </div>
+        <% else %>
+          <%= button_to go_to_path(login_configuration), class: "button primary my-10 flex items-center justify-center appearance-none", autofocus: !celebrate do %>
+            <span class="text-center">
+              <% if relying_party.supports_legacy_accounts? && current_user.data.id_for(relying_party.id).blank? %>
+                <%= t('.create_account_html', relying_party_name: relying_party.name) %>
+              <% else %>
+                <%= t('.go_to_html', relying_party_name: relying_party.name) %>
+              <% end %>
+            </span>
+            <span class="ml-3">
+              &rarr;
+            </span>
+          <% end %>
         <% end %>
 
         <div class="flex flex-col items-center">

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -8,3 +8,6 @@ end
 Ahoy.api = true
 Ahoy.mask_ips = true
 Ahoy.cookies = false
+# The geocode job enqueues to RabbitMQ, which the test env doesn't run —
+# a request with a real-browser user agent would 500 on visit creation.
+Ahoy.geocode = false if Rails.env.test?

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -145,6 +145,8 @@ da:
       you_are_html: Du er logget ind som <strong>%{email}</strong>.
       go_to_html: "Videre til <strong>%{relying_party_name}</strong>"
       create_account_html: "Opret ny identitet på <strong>%{relying_party_name}</strong>"
+      continue_in_app_html: Fortsæt i <strong>%{relying_party_name}</strong>-appen på din telefon
+      continue_in_app_help_html: "%{relying_party_name} kan ikke åbnes fra denne computer. Åbn appen på din telefon — du kan logge ind med din e-mail og dit nye password."
       not_you_html: Er <strong>%{email}</strong> ikke dig?
       logout: Log ud
       no_sharing_html: <strong>Ingen personlig data vil blive delt med %{relying_party_name}</strong>. Heller ikke din e-mail. De vil udelukkende få et unikt ID som identificerer dig.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,8 @@ en:
       you_are_html: You are signed in as <strong>%{email}</strong>.
       go_to_html: "Go to <strong>%{relying_party_name}</strong>"
       create_account_html: Create new identity for <strong>%{relying_party_name}</strong>
+      continue_in_app_html: Continue in the <strong>%{relying_party_name}</strong> app on your phone
+      continue_in_app_help_html: "%{relying_party_name} can't be opened from this computer. Open the app on your phone — you can sign in with your e-mail and your new password."
       not_you_html: Not <strong>%{email}</strong>?
       logout: Logout
       no_sharing_html: <strong>No personal information will be shared with %{relying_party_name}</strong>. Not even your e-mail. All they will get is a unique string identifying you.

--- a/test/controllers/authentication_controller_test.rb
+++ b/test/controllers/authentication_controller_test.rb
@@ -184,6 +184,103 @@ class AuthenticationControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'go_to with a custom-scheme redirect keeps the session for a retry' do
+    Trust::Certificate.generate_key_pair!
+
+    relying_party = Authentication::RelyingParty.new(
+      id: 'example.com', name: 'Example', allowed_redirect_uris: ['example-app://authenticate']
+    )
+    Authentication::Services::Authenticate.new(email: 'hello@world.com', password: 'secr2t').register!
+    post authenticate_url, params: { email: 'hello@world.com', password: 'secr2t' }
+
+    iphone = { 'HTTP_USER_AGENT' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15' }
+    Authentication::RelyingParty.stub :find, relying_party do
+      post go_to_url, params: { client_id: 'example.com', redirect_uri: 'example-app://authenticate' }, headers: iphone
+      assert_match %r{\Aexample-app://authenticate\?id_token=}, response.redirect_url
+
+      # The custom-scheme handoff may have gone nowhere (app hiccup,
+      # dismissed prompt) — a second press must re-issue instead of
+      # bouncing to login.
+      post go_to_url, params: { client_id: 'example.com', redirect_uri: 'example-app://authenticate' }, headers: iphone
+      assert_match %r{\Aexample-app://authenticate\?id_token=}, response.redirect_url
+    end
+  end
+
+  test 'go_to on desktop with a custom-scheme redirect lands on confirm' do
+    Trust::Certificate.generate_key_pair!
+
+    relying_party = Authentication::RelyingParty.new(
+      id: 'example.com', name: 'Example', allowed_redirect_uris: ['example-app://authenticate']
+    )
+    Authentication::Services::Authenticate.new(email: 'hello@world.com', password: 'secr2t').register!
+    post authenticate_url, params: { email: 'hello@world.com', password: 'secr2t' }
+
+    Authentication::RelyingParty.stub :find, relying_party do
+      post go_to_url, params: { client_id: 'example.com', redirect_uri: 'example-app://authenticate' }
+      assert_redirected_to confirm_path(client_id: 'example.com', redirect_uri: 'example-app://authenticate')
+
+      # No token was burned and the session survives — confirm renders.
+      get confirm_path(client_id: 'example.com', redirect_uri: 'example-app://authenticate')
+      assert_response :success
+    end
+  end
+
+  test 'go_to with a web redirect still forgets the session' do
+    Trust::Certificate.generate_key_pair!
+
+    Authentication::Services::Authenticate.new(email: 'hello@world.com', password: 'secr2t').register!
+    post authenticate_url, params: { email: 'hello@world.com', password: 'secr2t' }
+
+    Authentication::RelyingParty.stub :fetch, nil do
+      post go_to_url, params: { client_id: 'example.com', redirect_uri: 'https://example.com/hello' }
+      assert_match %r{\Ahttps://example.com/hello\?id_token=}, response.redirect_url
+
+      post go_to_url, params: { client_id: 'example.com', redirect_uri: 'https://example.com/hello' }
+      assert_match %r{/login}, response.redirect_url
+    end
+  end
+
+  test 'confirm shows app guidance on desktop when the handoff is a custom scheme' do
+    relying_party = Authentication::RelyingParty.new(
+      id: 'example.com', name: 'Example', allowed_redirect_uris: ['example-app://authenticate']
+    )
+    Authentication::Services::Authenticate.new(email: 'hello@world.com', password: 'secr2t').register!
+    post authenticate_url, params: { email: 'hello@world.com', password: 'secr2t' }
+
+    Authentication::RelyingParty.stub :find, relying_party do
+      get confirm_path(client_id: 'example.com', redirect_uri: 'example-app://authenticate')
+      assert_response :success
+      assert_select 'form[action*="go_to"]', count: 0
+      assert_select 'p', /on your phone/
+    end
+  end
+
+  test 'confirm keeps the go-to button on a phone for a custom-scheme handoff' do
+    relying_party = Authentication::RelyingParty.new(
+      id: 'example.com', name: 'Example', allowed_redirect_uris: ['example-app://authenticate']
+    )
+    Authentication::Services::Authenticate.new(email: 'hello@world.com', password: 'secr2t').register!
+    post authenticate_url, params: { email: 'hello@world.com', password: 'secr2t' }
+
+    Authentication::RelyingParty.stub :find, relying_party do
+      get confirm_path(client_id: 'example.com', redirect_uri: 'example-app://authenticate'),
+          headers: { 'HTTP_USER_AGENT' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15' }
+      assert_response :success
+      assert_select 'form[action*="go_to"]'
+    end
+  end
+
+  test 'confirm keeps the go-to button for web handoffs on desktop' do
+    Authentication::Services::Authenticate.new(email: 'hello@world.com', password: 'secr2t').register!
+    post authenticate_url, params: { email: 'hello@world.com', password: 'secr2t' }
+
+    Authentication::RelyingParty.stub :fetch, nil do
+      get confirm_path(client_id: 'example.com', redirect_uri: 'https://example.com/hello')
+      assert_response :success
+      assert_select 'form[action*="go_to"]'
+    end
+  end
+
   test 'go_to relying party' do
     Trust::Certificate.generate_key_pair!
 


### PR DESCRIPTION
## The bug (hit in production today)

Registering (or signing in) on a desktop browser inside a flow the Oase app initiated — so `redirect_uri=oase://authenticate` — ended in a silent dead end:

1. Pressing "Gå til Oase" issued the id_token and 302'd to `oase://authenticate?...`, which desktop browsers refuse (*"Prevented navigation … unknown protocol"*). Visually, nothing happened.
2. `go_to` had already `reset_session` (forget-me-after-handoff).
3. The inevitable second press carried a CSRF token from the dead session → bounced to `/login`. To the user: logged out right after creating their account.

## The fix

- **`go_to` keeps the session on custom-scheme handoffs** — a re-press re-issues the token instead of bouncing to login. Web (https) handoffs keep the forget-me behavior.
- **`go_to` on a desktop user agent + custom scheme routes to `/confirm`** instead of burning a token on a dead redirect. Since `authenticate` funnels through `go_to`, this also covers existing users signing in with the app's redirect_uri on desktop.
- **`/confirm` swaps the go-button for guidance** on such devices: continue in the app on your phone (where, since #225, the in-app sheet auto-advances to the password prompt). Danish + English copy.
- New `custom_scheme_handoff?` / `mobile_device?` helpers in `RelyingPartyConcern`. iPads in desktop mode get the desktop treatment — acceptable coarseness, documented in the code.
- Test-env fix: Ahoy geocoding disabled in tests (its job enqueues to RabbitMQ, which tests don't run; any real-browser user agent 500'd on visit creation).

## Testing

- 5 new controller tests: retry-after-handoff keeps the session (phone UA), web handoff still forgets it, desktop go_to lands on confirm, confirm shows guidance on desktop / keeps the button on the phone and for web handoffs. Full suite: 119 runs, 0 failures.
- Reproduced the exact production sequence in dev (desktop sign-in with `redirect_uri=oase://authenticate`): now lands on confirm, signed in, with the guidance panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)