### PR TITLE
Blame the app link, not the relying party, in the handoff guidance

### DIFF
--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -146,7 +146,7 @@ da:
       go_to_html: "Videre til <strong>%{relying_party_name}</strong>"
       create_account_html: "Opret ny identitet på <strong>%{relying_party_name}</strong>"
       continue_in_app_html: Fortsæt i <strong>%{relying_party_name}</strong>-appen på din telefon
-      continue_in_app_help_html: "%{relying_party_name} kan ikke åbnes fra denne computer. Åbn appen på din telefon — du kan logge ind med din e-mail og dit nye password."
+      continue_in_app_help_html: "Linket tilbage til appen virker ikke på en computer. Åbn %{relying_party_name}-appen på din telefon og log ind med din e-mail og dit password."
       not_you_html: Er <strong>%{email}</strong> ikke dig?
       logout: Log ud
       no_sharing_html: <strong>Ingen personlig data vil blive delt med %{relying_party_name}</strong>. Heller ikke din e-mail. De vil udelukkende få et unikt ID som identificerer dig.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,7 +146,7 @@ en:
       go_to_html: "Go to <strong>%{relying_party_name}</strong>"
       create_account_html: Create new identity for <strong>%{relying_party_name}</strong>
       continue_in_app_html: Continue in the <strong>%{relying_party_name}</strong> app on your phone
-      continue_in_app_help_html: "%{relying_party_name} can't be opened from this computer. Open the app on your phone — you can sign in with your e-mail and your new password."
+      continue_in_app_help_html: "The link back to the app doesn't work on a computer. Open the %{relying_party_name} app on your phone and sign in with your e-mail and password."
       not_you_html: Not <strong>%{email}</strong>?
       logout: Logout
       no_sharing_html: <strong>No personal information will be shared with %{relying_party_name}</strong>. Not even your e-mail. All they will get is a unique string identifying you.


### PR DESCRIPTION
Copy fix for the confirm-page guidance shipped in #226. "Oase kan ikke åbnes fra denne computer" was technically wrong — Promise doesn't know whether the relying party works on a computer (Oase does); it's the app's custom-scheme redirect link that doesn't open here. New copy:

> Linket tilbage til appen virker ikke på en computer. Åbn Oase-appen på din telefon og log ind med din e-mail og dit password.

Also drops "dit **nye** password", since the same panel shows for existing users signing in, not just fresh registrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)