### PR TITLE
Detect a dead app handoff reactively instead of UA-sniffing

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -25,13 +25,6 @@ class AuthenticationController < ApplicationController
 
   def go_to
     if relying_party.present?
-      # A custom-scheme handoff on a device without the app dies silently
-      # (desktop browsers refuse the navigation), so don't burn a token on
-      # it — land on confirm, which explains how to continue in the app.
-      # authenticate funnels through here too, so this also covers an
-      # existing user signing in with the app's redirect_uri on desktop.
-      return redirect_to confirm_path(login_configuration) if custom_scheme_handoff? && !mobile_device?
-
       id_token = Authentication::Services::GetIdToken.new(
         user_id: current_user.id,
         relying_party_id: relying_party.id,

--- a/app/controllers/concerns/relying_party_concern.rb
+++ b/app/controllers/concerns/relying_party_concern.rb
@@ -4,7 +4,6 @@ module RelyingPartyConcern
   included do
     helper_method :relying_party
     helper_method :custom_scheme_handoff?
-    helper_method :mobile_device?
   end
 
   def relying_party
@@ -25,12 +24,5 @@ module RelyingPartyConcern
     scheme.present? && !%w[http https].include?(scheme)
   rescue URI::InvalidURIError
     false
-  end
-
-  # Coarse on purpose: only used to pick copy/affordances for handoffs the
-  # current device plainly cannot perform. iPads in desktop mode report a
-  # Mac user agent and get the desktop treatment — acceptable.
-  def mobile_device?
-    request.user_agent.to_s.match?(/iPhone|iPad|iPod|Android/i)
   end
 end

--- a/app/views/authentication/confirm.html.erb
+++ b/app/views/authentication/confirm.html.erb
@@ -77,36 +77,54 @@
         <p class="text-secondary text-sm max-w-xs text-center mt-3">
           <%= t '.you_are_html', email: current_user.email, name: name %>
         </p>
-        <% if custom_scheme_handoff? && !mobile_device? %>
-          <%# The final redirect targets the relying party's native app via
-              a custom URL scheme — this device can't open it (desktop
-              browsers refuse the navigation and the button would appear to
-              do nothing). Point the user back to the device the app lives
-              on instead. %>
-          <div class="my-10 w-full max-w-xs rounded-xl border border-blue-200 bg-blue-50 p-4 text-center">
+        <%= button_to go_to_path(login_configuration), form: { id: 'go-to-app' }, class: "button primary my-10 flex items-center justify-center appearance-none", autofocus: !celebrate do %>
+          <span class="text-center">
+            <% if relying_party.supports_legacy_accounts? && current_user.data.id_for(relying_party.id).blank? %>
+              <%= t('.create_account_html', relying_party_name: relying_party.name) %>
+            <% else %>
+              <%= t('.go_to_html', relying_party_name: relying_party.name) %>
+            <% end %>
+          </span>
+          <span class="ml-3">
+            &rarr;
+          </span>
+        <% end %>
+        <% if custom_scheme_handoff? %>
+          <%# The final redirect hands off to the relying party's native app
+              via a custom URL scheme. A device without the app refuses that
+              navigation silently and stays right here — so reveal help a
+              beat after the press. When the handoff works, the app covers
+              the page and nobody sees it. UA sniffing can't make this call:
+              tablets in desktop-site mode report desktop user agents. %>
+          <div id="app-handoff-fallback" hidden class="mb-10 -mt-4 w-full max-w-xs rounded-xl border border-blue-200 bg-blue-50 p-4 text-center">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="mx-auto h-7 w-7 text-blue-700">
               <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 0 0 6 3.75v16.5a2.25 2.25 0 0 0 2.25 2.25h7.5A2.25 2.25 0 0 0 18 20.25V3.75a2.25 2.25 0 0 0-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3" />
             </svg>
             <p class="mt-2 font-semibold text-primary">
-              <%= t '.continue_in_app_html', relying_party_name: relying_party.name %>
+              <%= t '.app_did_not_open_html', relying_party_name: relying_party.name %>
             </p>
             <p class="mt-2 text-sm text-primary">
-              <%= t '.continue_in_app_help_html', relying_party_name: relying_party.name %>
+              <%= t '.app_did_not_open_help_html', relying_party_name: relying_party.name %>
             </p>
           </div>
-        <% else %>
-          <%= button_to go_to_path(login_configuration), class: "button primary my-10 flex items-center justify-center appearance-none", autofocus: !celebrate do %>
-            <span class="text-center">
-              <% if relying_party.supports_legacy_accounts? && current_user.data.id_for(relying_party.id).blank? %>
-                <%= t('.create_account_html', relying_party_name: relying_party.name) %>
-              <% else %>
-                <%= t('.go_to_html', relying_party_name: relying_party.name) %>
-              <% end %>
-            </span>
-            <span class="ml-3">
-              &rarr;
-            </span>
-          <% end %>
+          <script>
+            (function () {
+              var form = document.getElementById('go-to-app');
+              var fallback = document.getElementById('app-handoff-fallback');
+              if (!form || !fallback) return;
+              var timer;
+              form.addEventListener('submit', function () {
+                clearTimeout(timer);
+                timer = setTimeout(function () { fallback.hidden = false; }, 2500);
+              });
+              // The page going hidden means the app (or its open-prompt)
+              // took over — the handoff worked, keep the help away.
+              document.addEventListener('visibilitychange', function () {
+                if (document.hidden) clearTimeout(timer);
+              });
+              window.addEventListener('pagehide', function () { clearTimeout(timer); });
+            })();
+          </script>
         <% end %>
 
         <div class="flex flex-col items-center">

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -145,8 +145,8 @@ da:
       you_are_html: Du er logget ind som <strong>%{email}</strong>.
       go_to_html: "Videre til <strong>%{relying_party_name}</strong>"
       create_account_html: "Opret ny identitet på <strong>%{relying_party_name}</strong>"
-      continue_in_app_html: Fortsæt i <strong>%{relying_party_name}</strong>-appen på din telefon
-      continue_in_app_help_html: "Linket tilbage til appen virker ikke på en computer. Åbn %{relying_party_name}-appen på din telefon og log ind med din e-mail og dit password."
+      app_did_not_open_html: Åbnede <strong>%{relying_party_name}</strong>-appen ikke?
+      app_did_not_open_help_html: "Tryk på knappen igen for at prøve igen. Ligger appen på en anden enhed, så åbn %{relying_party_name}-appen dér og log ind med din e-mail og dit password."
       not_you_html: Er <strong>%{email}</strong> ikke dig?
       logout: Log ud
       no_sharing_html: <strong>Ingen personlig data vil blive delt med %{relying_party_name}</strong>. Heller ikke din e-mail. De vil udelukkende få et unikt ID som identificerer dig.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,8 +145,8 @@ en:
       you_are_html: You are signed in as <strong>%{email}</strong>.
       go_to_html: "Go to <strong>%{relying_party_name}</strong>"
       create_account_html: Create new identity for <strong>%{relying_party_name}</strong>
-      continue_in_app_html: Continue in the <strong>%{relying_party_name}</strong> app on your phone
-      continue_in_app_help_html: "The link back to the app doesn't work on a computer. Open the %{relying_party_name} app on your phone and sign in with your e-mail and password."
+      app_did_not_open_html: Didn't the <strong>%{relying_party_name}</strong> app open?
+      app_did_not_open_help_html: "Press the button to try again. If the app lives on another device, open the %{relying_party_name} app there and sign in with your e-mail and password."
       not_you_html: Not <strong>%{email}</strong>?
       logout: Logout
       no_sharing_html: <strong>No personal information will be shared with %{relying_party_name}</strong>. Not even your e-mail. All they will get is a unique string identifying you.

--- a/test/controllers/authentication_controller_test.rb
+++ b/test/controllers/authentication_controller_test.rb
@@ -206,7 +206,7 @@ class AuthenticationControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'go_to on desktop with a custom-scheme redirect lands on confirm' do
+  test 'go_to attempts a custom-scheme handoff regardless of user agent' do
     Trust::Certificate.generate_key_pair!
 
     relying_party = Authentication::RelyingParty.new(
@@ -215,12 +215,16 @@ class AuthenticationControllerTest < ActionDispatch::IntegrationTest
     Authentication::Services::Authenticate.new(email: 'hello@world.com', password: 'secr2t').register!
     post authenticate_url, params: { email: 'hello@world.com', password: 'secr2t' }
 
+    # A desktop user agent is no proof the app is absent: tablets in
+    # desktop-site mode report one (Samsung tablets do by default). The
+    # confirm page handles a dead redirect reactively instead.
+    desktop = { 'HTTP_USER_AGENT' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36' }
     Authentication::RelyingParty.stub :find, relying_party do
-      post go_to_url, params: { client_id: 'example.com', redirect_uri: 'example-app://authenticate' }
-      assert_redirected_to confirm_path(client_id: 'example.com', redirect_uri: 'example-app://authenticate')
+      post go_to_url, params: { client_id: 'example.com', redirect_uri: 'example-app://authenticate' }, headers: desktop
+      assert_match %r{\Aexample-app://authenticate\?id_token=}, response.redirect_url
 
-      # No token was burned and the session survives — confirm renders.
-      get confirm_path(client_id: 'example.com', redirect_uri: 'example-app://authenticate')
+      # The session survives the attempt — confirm still renders for a retry.
+      get confirm_path(client_id: 'example.com', redirect_uri: 'example-app://authenticate'), headers: desktop
       assert_response :success
     end
   end
@@ -240,7 +244,7 @@ class AuthenticationControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'confirm shows app guidance on desktop when the handoff is a custom scheme' do
+  test 'confirm shows the go-to button and a hidden fallback for a custom-scheme handoff' do
     relying_party = Authentication::RelyingParty.new(
       id: 'example.com', name: 'Example', allowed_redirect_uris: ['example-app://authenticate']
     )
@@ -248,29 +252,17 @@ class AuthenticationControllerTest < ActionDispatch::IntegrationTest
     post authenticate_url, params: { email: 'hello@world.com', password: 'secr2t' }
 
     Authentication::RelyingParty.stub :find, relying_party do
-      get confirm_path(client_id: 'example.com', redirect_uri: 'example-app://authenticate')
-      assert_response :success
-      assert_select 'form[action*="go_to"]', count: 0
-      assert_select 'p', /on your phone/
-    end
-  end
-
-  test 'confirm keeps the go-to button on a phone for a custom-scheme handoff' do
-    relying_party = Authentication::RelyingParty.new(
-      id: 'example.com', name: 'Example', allowed_redirect_uris: ['example-app://authenticate']
-    )
-    Authentication::Services::Authenticate.new(email: 'hello@world.com', password: 'secr2t').register!
-    post authenticate_url, params: { email: 'hello@world.com', password: 'secr2t' }
-
-    Authentication::RelyingParty.stub :find, relying_party do
+      # Desktop user agent on purpose: the button must never be hidden by
+      # UA sniffing — tablets in desktop-site mode report desktop UAs.
       get confirm_path(client_id: 'example.com', redirect_uri: 'example-app://authenticate'),
-          headers: { 'HTTP_USER_AGENT' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15' }
+          headers: { 'HTTP_USER_AGENT' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36' }
       assert_response :success
       assert_select 'form[action*="go_to"]'
+      assert_select '#app-handoff-fallback[hidden]'
     end
   end
 
-  test 'confirm keeps the go-to button for web handoffs on desktop' do
+  test 'confirm keeps the go-to button and skips the fallback for web handoffs' do
     Authentication::Services::Authenticate.new(email: 'hello@world.com', password: 'secr2t').register!
     post authenticate_url, params: { email: 'hello@world.com', password: 'secr2t' }
 
@@ -278,6 +270,7 @@ class AuthenticationControllerTest < ActionDispatch::IntegrationTest
       get confirm_path(client_id: 'example.com', redirect_uri: 'https://example.com/hello')
       assert_response :success
       assert_select 'form[action*="go_to"]'
+      assert_select '#app-handoff-fallback', count: 0
     end
   end
 


### PR DESCRIPTION
## Problem

A user reported that their kid's Samsung tablet couldn't use the Oase app: the sign-in flow told him "the link back to the app doesn't work on a computer" and hid the go-to-app button.

Cause: Chrome on large Android tablets (and Samsung Internet in desktop-site/DeX mode) requests desktop sites by default, so the user agent carries no `Android` token. `mobile_device?` classified the tablet as a desktop and the confirm page suppressed the button — even though the app was installed and the `oase://` redirect would have worked.

## Fix: stop predicting, react instead

UA sniffing fundamentally can't tell whether a device can open a custom scheme, so this removes the guess entirely:

- `go_to` always attempts the custom-scheme redirect (gate removed, `mobile_device?` deleted).
- The confirm page always shows the button. For custom-scheme handoffs it also renders a hidden "Didn't the app open?" panel, revealed 2.5s after the button press. The key insight: **when the handoff works, the app covers the page and nobody sees the panel** — only users whose redirect went nowhere are still looking. `visibilitychange`/`pagehide` cancel the reveal.
- Retry is safe: the session already survives custom-scheme handoffs (7d581ff), so a re-press re-issues the token. The gesture from the press carries through the 302 chain, which is what Chrome requires for external-app launches (a JS auto-redirect on a fresh page would be blocked).
- New copy makes no device assumptions: "Press the button to try again. If the app lives on another device, open it there and sign in with your e-mail and password."

Oase app constraints are intact: `redirect_uri` still fires when the flow finishes in a different browser (now in strictly more cases than before), and the typeable-code fallback is untouched.

## Tests

118 runs, 0 failures. Desktop-UA tests rewritten: `go_to` with an X11/Linux UA (the Samsung-tablet signature) now asserts the `example-app://` redirect and a surviving session; confirm asserts button + hidden fallback regardless of UA, and no fallback for web handoffs.

Not covered by tests: the 2.5s timer behavior itself — worth a manual pass on a desktop browser with `redirect_uri=oase://authenticate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)