### PR TITLE
Clear mail deliveries before the verification-code test

### DIFF
--- a/test/domain/authentication/services/prepare_email_for_validation_test.rb
+++ b/test/domain/authentication/services/prepare_email_for_validation_test.rb
@@ -3,6 +3,9 @@ require 'test_helper'
 class Authentication::Services::PrepareEmailForValidationTest < ActiveSupport::TestCase
   setup do
     @described_class = Authentication::Services::PrepareEmailForValidation
+    # Deliveries accumulate across the tests sharing this process — the
+    # absolute size assertion below is only meaningful from a clean slate.
+    ActionMailer::Base.deliveries.clear
   end
 
   test 'it should be valid' do


### PR DESCRIPTION
The `main` CI run for PR #228 failed on `PrepareEmailForValidationTest` — expected 2 deliveries, saw 3. The test asserts an **absolute** `ActionMailer::Base.deliveries.size`, but deliveries accumulate across all tests sharing a parallel CI process, so the assertion only holds when no earlier test in that process sent mail. PR #228 renamed two tests, which reshuffled the distribution and surfaced the latent flake.

Fix: clear `deliveries` in `setup`, making the count deterministic regardless of process assignment.

Verified by reproducing with CI's exact conditions (`PARALLEL_WORKERS=4 bin/rails test --seed 5466`): fails without the fix, green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)